### PR TITLE
Fixed : HighlightRange at index 0 was skipped

### DIFF
--- a/Highlighter/NSAttributedString+Extensions.swift
+++ b/Highlighter/NSAttributedString+Extensions.swift
@@ -19,7 +19,7 @@ extension NSAttributedString {
 
         } else {
             for i in 1..<ranges.count {
-                highlightString.append(self.containAttribute(originText: originText, bound: ranges[i], attributes: highlightAttributes))
+                highlightString.append(self.containAttribute(originText: originText, bound: ranges[i-1], attributes: highlightAttributes))
                 highlightString.append(self.continueAttribute(originText: originText, upperBound: ranges[i-1].upperBound, lowerBound: ranges[i].lowerBound, normalAttributes: normalAttributes))
             }
 


### PR DESCRIPTION
This caused a bug that converted Upper case match to lower case.
i,e originText = “Ajith” would appear as “ajith” when highlight is requested for “a”